### PR TITLE
change locale to en

### DIFF
--- a/src/generic_lsp/commands.cljs
+++ b/src/generic_lsp/commands.cljs
@@ -89,7 +89,7 @@
           init-res (rpc/send! server "initialize"
                               {:processId nil
                                :clientInfo {:name "Pulsar"}
-                               :locale "UTF-8"
+                               :locale "en"
                                :capabilities {:textDocument {:synchronization {:didSave true}
                                                              :completion {:contextSupport true
                                                                           :completionItem {:snippetSupport true


### PR DESCRIPTION
This changes locale from `UTF-8` (why?) to `en`.